### PR TITLE
Update EDL setup instructions in user manual

### DIFF
--- a/docs-en/docs/rubik-pi-3-user-manual/1.0.0-u/2.set-up-your-device.md
+++ b/docs-en/docs/rubik-pi-3-user-manual/1.0.0-u/2.set-up-your-device.md
@@ -303,21 +303,22 @@ If the device is pre-flashed and fully provisioned, EDL mode can be skipped duri
 	<Tabs>
 	<TabItem value="method1" label="Method1">
 
-	1️⃣ Press and hold the **[EDL]** button (No. 12 in the figure above).
+	1️⃣ Disconnect the power supply from port 10, and the Type-C cable from port 5.
+
+	2️⃣ Press and hold the **[EDL]** button (No. 12 in the figure above).
 
 	![](./images/image-19.jpg)
 
-	2️⃣ Connect the power supply into port 10, as shown in the figure below.
+	3️⃣ While continuing to hold the **[EDL]** button, connect the power supply into port 10, as shown in the figure below.
 
 	![](./images/image-20.jpg)
 
-	3️⃣ Insert the Type-C cable into port 5 and wait three seconds to enter 9008 mode.
+	4️⃣ While continuing to hold the **[EDL]** button insert the Type-C cable into port 5 and wait three seconds to enter 9008 mode.
 
 	![](./images/20250314-155547.jpg)
    
-    4️⃣ Release EDL button
-    
-    5️⃣ You can observe that the device enter into EDL mode.
+    5️⃣ Release EDL button
+
 	</TabItem>
 	<TabItem value="method2" label="Method2">
     If your device is already running a Canonical Ubuntu image, follow the steps below to enter EDL (Emergency Download) mode.


### PR DESCRIPTION
Clean up EDL mode instructions for ubuntu version.

I've introduced some people to the hardware, and provided them the docs to get started. They found it wasn't clear that power needed to be disconnected prior to entering EDL mode, and that it was unclear that the EDL button needed to be held throughout the process. This PR attempts to improve the communication of that information.